### PR TITLE
Add tests for casting

### DIFF
--- a/src/GraphUtil.ts
+++ b/src/GraphUtil.ts
@@ -1,6 +1,7 @@
 import * as HasCycle from './util/HasCycle'
 import * as FindShortestPath from './util/FindShortestPath'
 import * as j from './util/json'
+import * as caster from './util/GetExplicitGraph'
 
 export const hasCycle = HasCycle.hasCycle
 
@@ -10,3 +11,5 @@ export const json = {
   stringify: j.stringify,
   parse: j.parse
 }
+
+export const castGraph = caster.castExplicitly

--- a/src/types/GraphType.ts
+++ b/src/types/GraphType.ts
@@ -1,7 +1,7 @@
 
 export enum GraphType {
-  WeightedDirected,
-  NonWeightedDirected,
-  WeightedUndirected,
-  NonWeightedUndirected
+  WeightedDirected = 'WeightedDirected',
+  NonWeightedDirected = 'NonWeightedDirected',
+  WeightedUndirected = 'WeightedUndirected',
+  NonWeightedUndirected = 'NonWeightedUndirected'
 }

--- a/src/util/GetExplicitGraph.ts
+++ b/src/util/GetExplicitGraph.ts
@@ -1,0 +1,47 @@
+import { GraphInterface } from '../types/GraphInterface'
+import { GraphType } from '../types/GraphType'
+import { WeightedDirectedGraph } from '../WeightedDirectedGraph'
+import { DirectedGraph } from '../DirectedGraph'
+import { WeightedUndirectedGraph } from '../WeightedUndirectedGraph'
+import { UndirectedGraph } from '../UndirectedGraph'
+
+type CastedType<V, E> = {
+  type: GraphType.WeightedDirected,
+  graph: WeightedDirectedGraph<V, E>
+} | {
+  type: GraphType.NonWeightedDirected,
+  graph: DirectedGraph<V, E>
+} | {
+  type: GraphType.WeightedUndirected,
+  graph: WeightedUndirectedGraph<V, E>
+} | {
+  type: GraphType.NonWeightedUndirected,
+  graph: UndirectedGraph<V, E>
+}
+
+export const castExplicitly = <V, E> (g: GraphInterface<V, E>): CastedType<V, E> => {
+  switch (g.getGraphType()) {
+    case GraphType.WeightedDirected:
+      return {
+        type: GraphType.WeightedDirected,
+        graph: g as WeightedDirectedGraph<V, E>
+      }
+    case GraphType.NonWeightedDirected:
+      return {
+        type: GraphType.NonWeightedDirected,
+        graph: g as unknown as DirectedGraph<V, E>
+      }
+    case GraphType.WeightedUndirected:
+      return {
+        type: GraphType.WeightedUndirected,
+        graph: g as WeightedUndirectedGraph<V, E>
+      }
+    case GraphType.NonWeightedUndirected:
+      return {
+        type: GraphType.NonWeightedUndirected,
+        graph: g as unknown as UndirectedGraph<V, E>
+      }
+    default:
+      throw new Error('No case found')
+  }
+}

--- a/test/util/GraphCast.test.ts
+++ b/test/util/GraphCast.test.ts
@@ -1,0 +1,39 @@
+import { describe, it } from 'mocha'
+import { expect } from 'chai'
+import { GraphInterface } from '../../src/types/GraphInterface'
+import { WeightedDirectedGraph } from '../../src/WeightedDirectedGraph'
+import { GraphUtil } from '../../index'
+import { GraphType } from '../../src/types/GraphType'
+import { DirectedGraph } from '../../src/DirectedGraph'
+import { UndirectedGraph } from '../../src/UndirectedGraph'
+import { WeightedUndirectedGraph } from '../../src/WeightedUndirectedGraph'
+
+describe('Test graph cast so that GraphInterface values can be safely casted' +
+  ' explicitly using discriminated unions', function () {
+  it('should cast to WeightedDirectedGraph', function (done) {
+    let graph = new WeightedDirectedGraph<string, number>() as GraphInterface<string>
+    /*
+    You can check that you cannot use WeightedDirectedGraph specific properties,
+    like getEdgeValue().
+     */
+    let castedResult = GraphUtil.castGraph(graph)
+    expect(castedResult.type).equals(GraphType.WeightedDirected)
+    if (castedResult.type === GraphType.WeightedDirected) {
+      Object.keys(castedResult.graph).includes('getEdgeValue')
+    } else {
+      return done('Bad')
+    }
+    graph = new DirectedGraph<string>() as GraphInterface<string>
+    castedResult = GraphUtil.castGraph(graph)
+    expect(castedResult.type).equals(GraphType.NonWeightedDirected)
+
+    graph = new UndirectedGraph<string>() as GraphInterface<string>
+    castedResult = GraphUtil.castGraph(graph)
+    expect(castedResult.type).equals(GraphType.NonWeightedUndirected)
+
+    graph = new WeightedUndirectedGraph<string, number>() as GraphInterface<string>
+    castedResult = GraphUtil.castGraph(graph)
+    expect(castedResult.type).equals(GraphType.WeightedUndirected)
+    done()
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,12 +29,12 @@
     /* Strict Type-Checking Options */
     "strict": true /* Enable all strict type-checking options. */,
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,              /* Enable strict null checks. */
+     "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+     "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 
     /* Additional Checks */
     // "noUnusedLocals": true,                /* Report errors on unused locals. */


### PR DESCRIPTION
Add function that safely casts a GraphInterface<V, E> to an explicit graph class type.